### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -35,62 +35,36 @@
       "inputs": ["default", "^default"]
     }
   },
-  "workspaceLayout": {
-    "appsDir": "apps",
-    "libsDir": "libs"
-  },
+  "workspaceLayout": { "appsDir": "apps", "libsDir": "libs" },
   "generators": {
     "@nx/js:library": {
       "buildable": true,
       "publishable": false,
       "importPath": "@dfs-invest-flow/{projectName}"
     },
-    "@nx/nest:application": {
-      "strict": true,
-      "unitTestRunner": "jest"
-    },
+    "@nx/nest:application": { "strict": true, "unitTestRunner": "jest" },
     "@nx/next:application": {
       "style": "css",
       "unitTestRunner": "jest",
       "e2eTestRunner": "playwright"
     },
-    "@nx/react:library": {
-      "unitTestRunner": "jest",
-      "bundler": "vite"
-    }
+    "@nx/react:library": { "unitTestRunner": "jest", "bundler": "vite" }
   },
   "projects": {
-    "api": {
-      "tags": ["scope:api", "type:app", "framework:nest"]
-    },
-    "web": {
-      "tags": ["scope:web", "type:app", "framework:next"]
-    },
-    "domain": {
-      "tags": ["scope:domain", "type:lib", "layer:domain"]
-    },
+    "api": { "tags": ["scope:api", "type:app", "framework:nest"] },
+    "web": { "tags": ["scope:web", "type:app", "framework:next"] },
+    "domain": { "tags": ["scope:domain", "type:lib", "layer:domain"] },
     "application": {
       "tags": ["scope:application", "type:lib", "layer:application"]
     },
     "infrastructure": {
       "tags": ["scope:infrastructure", "type:lib", "layer:infrastructure"]
     },
-    "shared": {
-      "tags": ["scope:shared", "type:lib", "layer:shared"]
-    }
+    "shared": { "tags": ["scope:shared", "type:lib", "layer:shared"] }
   },
   "plugins": [
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
-    {
-      "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      }
-    }
-  ]
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    { "plugin": "@nx/jest/plugin", "options": { "targetName": "test" } }
+  ],
+  "nxCloudId": "68127ca09c76d63ce41eb675"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68127c8b72b61fd02e1e2671/workspaces/68127ca09c76d63ce41eb675

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.